### PR TITLE
Fix build error due to translation

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -27,8 +27,8 @@
     <string name="profileTile">Profile</string>
 
     <!-- Shared Preferences -->
-    <string name="profile"/>
-    <string name="profilePath"/>
-    <string name="firstFind">true</string>
-    <string name="loadOnBoot">false</string>
+    <string name="profile" translatable="false" />
+    <string name="profilePath" translatable="false" />
+    <string name="firstFind" translatable="false">true</string>
+    <string name="loadOnBoot" translatable="false">false</string>
 </resources>


### PR DESCRIPTION
Commit be697a1ef5e24f54f3f3294515e72cfe7169e86c broke the build inadvertently.

"Explanation for issues of type "MissingTranslation":
If an application has more than one locale, then all the strings declared
in one language should also be translated in all other languages.

If the string should not be translated, you can add the attribute
translatable="false" on the <string> element, or you can define all your
non-translatable strings in a resource file called donottranslate.xml. Or,
you can ignore the issue with a tools:ignore="MissingTranslation"
attribute."

Signed-off-by: Nathan Chancellor <natechancellor@gmail.com>